### PR TITLE
Fix forbidden because of `userextras/authentication.kubernetes.io/credential-id`

### DIFF
--- a/templates/clusterrole.yml
+++ b/templates/clusterrole.yml
@@ -17,6 +17,7 @@ rules:
   - "userextras/scopes"
   - "userextras/remote-client-ip"
   - "tokenreviews"
+  - "userextras/authentication.kubernetes.io/credential-id"
   - "userextras/originaluser.jetstack.io-user"
   - "userextras/originaluser.jetstack.io-groups"
   - "userextras/originaluser.jetstack.io-extra"


### PR DESCRIPTION

Fixes https://github.com/TremoloSecurity/kube-oidc-proxy/issues/71